### PR TITLE
An attached network must be shown by its name beside the mapping name in the header section

### DIFF
--- a/src/components/2-molecules/Header.jsx
+++ b/src/components/2-molecules/Header.jsx
@@ -23,6 +23,7 @@ const outdatedLabel =
 const Header = (props) => {
     const {
         name,
+        currentNetwork,
         isModified = false,
         isValid = true,
         save,
@@ -39,13 +40,19 @@ const Header = (props) => {
     return (
         <Box className={classes.headerBox}>
             <Box width="100%" display="flex">
-                <Box className={classes.titleBox}>
+                <Box
+                    className={classes.titleBox}
+                    display="flex"
+                    alignItems="baseline"
+                >
                     <Tooltip title={isCurrent ? '' : outdatedLabel}>
-                        <Typography
-                            variant="h2"
-                            className={classes.title}
-                        >{`${name}${isModified ? '*' : ''} :`}</Typography>
+                        <Typography variant="h2" className={classes.title}>
+                            {`${name}${isModified ? '*' : ''} :`}
+                        </Typography>
                     </Tooltip>
+                    <Typography variant="h3" className={classes.title}>
+                        {`${currentNetwork?.networkName ?? ''}`}
+                    </Typography>
                 </Box>
                 <Box className={classes.buttonBox}>
                     {convert !== undefined && (
@@ -82,6 +89,10 @@ const Header = (props) => {
 
 Header.propTypes = {
     name: PropTypes.string.isRequired,
+    currentNetwork: PropTypes.shape({
+        networkId: PropTypes.string,
+        networkName: PropTypes.string,
+    }),
     isModified: PropTypes.bool,
     isValid: PropTypes.bool,
     isCurrent: PropTypes.bool,

--- a/src/containers/MappingContainer.jsx
+++ b/src/containers/MappingContainer.jsx
@@ -19,6 +19,7 @@ import {
 } from '../redux/slices/Mapping';
 import { convertScript } from '../redux/slices/Script';
 import {
+    getCurrentNetworkObj,
     getNetworkNames,
     getPropertyValuesFromFile,
     getPropertyValuesFromNetworkId,
@@ -67,6 +68,7 @@ const MappingContainer = () => {
     const isMappingValid = useSelector(isMappingValidSelector);
     const networks = useSelector((state) => state.network.knownNetworks);
     const networkValues = useSelector((state) => state.network.propertyValues);
+    const currentNetwork = useSelector(getCurrentNetworkObj);
     const sortedRulesNumber = useSelector(getSortedRulesNumber);
     const filteredType = useSelector(
         (state) => state.mappings.filteredRuleType
@@ -175,6 +177,7 @@ const MappingContainer = () => {
             <Paper>
                 <Header
                     name={activeMapping}
+                    currentNetwork={currentNetwork}
                     isModified={isModified}
                     isValid={isMappingValid && areParametersValid}
                     save={saveMapping}

--- a/src/redux/slices/Network.js
+++ b/src/redux/slices/Network.js
@@ -60,6 +60,17 @@ export const makeGetPossibleWatchedElements = () =>
             return ids;
         }
     );
+
+// from current network id => get network object
+export const getCurrentNetworkObj = (state) => {
+    const currentNetwork = state.network.currentNetwork;
+    return (
+        currentNetwork &&
+        state.network.knownNetworks?.find(
+            (knowNetwork) => knowNetwork.networkId === currentNetwork
+        )
+    );
+};
 // Reducers
 
 export const getPropertyValuesFromFile = createAsyncThunk(


### PR DESCRIPTION
An attached network must be shown by its name beside the mapping name in the header section