### PR TITLE
Can not create a new group in Automation

### DIFF
--- a/src/containers/AutomatonContainer.jsx
+++ b/src/containers/AutomatonContainer.jsx
@@ -74,11 +74,11 @@ const AutomatonContainer = ({ index, editParameters }) => {
     );
 
     const changeParameters = useCallback(
-        (newParameters) =>
+        (group) =>
             dispatch(
                 MappingSlice.actions.changeAutomatonParameters({
                     index,
-                    parameters: newParameters,
+                    parameters: group.name,
                 })
             ),
         [dispatch, index]

--- a/src/containers/ParametersContainer.jsx
+++ b/src/containers/ParametersContainer.jsx
@@ -110,18 +110,20 @@ const ParametersContainer = ({
     const addOrModifySet = (newSet) =>
         dispatch(ModelSlice.actions.addOrModifySet(newSet));
     const saveSetGroup = () => {
-        dispatch(postModelSetsGroup(controlledParameters));
-        const actionToDispatch =
-            origin === GroupEditionOrigin.RULE
-                ? MappingSlice.actions.changeRuleParameters
-                : MappingSlice.actions.changeAutomatonParameters;
-        dispatch(
-            actionToDispatch({
-                index: originIndex,
-                parameters: currentGroup.name,
-                type: currentGroup.type,
-            })
-        );
+        (async () => {
+            await dispatch(postModelSetsGroup(controlledParameters));
+            const actionToDispatch =
+                origin === GroupEditionOrigin.RULE
+                    ? MappingSlice.actions.changeRuleParameters
+                    : MappingSlice.actions.changeAutomatonParameters;
+            dispatch(
+                actionToDispatch({
+                    index: originIndex,
+                    parameters: currentGroup.name,
+                    type: currentGroup.type,
+                })
+            );
+        })();
         close();
     };
 


### PR DESCRIPTION
Only in Automation, when click the Create new group in drop-box, then click on the button with tooltip "Edit the parameters group and/or the parameters sets" => the dialog shown is not the one for create group.