### PR TITLE
Fixed and Network (origin) parameters must be not shown in the creation/editing group dialogue

### DIFF
--- a/src/components/3-organisms/SetEditor.jsx
+++ b/src/components/3-organisms/SetEditor.jsx
@@ -16,7 +16,7 @@ import { isParameterValueValid } from '../../utils/parameters';
 const infoTypeLabel = 'This parameter is of type ';
 const networkLabel = ' From Network';
 const SetEditor = (props) => {
-    const { definitions, set, saveSet } = props;
+    const { definitions, filterByOrigin, set, saveSet } = props;
     const valueOrigin = (origin) => {
         switch (origin) {
             case ParameterOrigin.USER:
@@ -49,6 +49,11 @@ const SetEditor = (props) => {
         <Box>
             <Typography variant="h2"> {set.name}</Typography>
             {_.cloneDeep(definitions)
+                .filter((definition) =>
+                    filterByOrigin
+                        ? filterByOrigin.includes(definition.origin)
+                        : true
+                )
                 .sort((a, b) => valueOrigin(a.origin) - valueOrigin(b.origin))
                 .map((definition) => {
                     const correspondingParameter = set.parameters.find(
@@ -100,6 +105,7 @@ const SetEditor = (props) => {
 SetEditor.propTypes = {
     set: PropTypes.object.isRequired,
     definitions: PropTypes.array.isRequired,
+    filterByOrigin: PropTypes.array, // undefined => show all, [] => do not show, [origin1, origin2] => show only in origin1 and origin2 category
     saveSet: PropTypes.func.isRequired,
 };
 

--- a/src/components/3-organisms/SetEditor.jsx
+++ b/src/components/3-organisms/SetEditor.jsx
@@ -16,7 +16,11 @@ import { isParameterValueValid } from '../../utils/parameters';
 const infoTypeLabel = 'This parameter is of type ';
 const networkLabel = ' From Network';
 const SetEditor = (props) => {
-    const { definitions, filterByOrigin, set, saveSet } = props;
+    const { definitions, filter, set, saveSet } = props;
+    const filteredDefinitions = filter
+        ? definitions.filter(filter)
+        : definitions;
+
     const valueOrigin = (origin) => {
         switch (origin) {
             case ParameterOrigin.USER:
@@ -33,7 +37,7 @@ const SetEditor = (props) => {
         const parameterChanged = event.target.id;
         const newValue = event.target.value;
         const newValueToUse =
-            definitions.find(
+            filteredDefinitions.find(
                 (definition) => definition.name === parameterChanged
             ).type === ParameterType.BOOL
                 ? newValue.replace(',', '.')
@@ -48,12 +52,7 @@ const SetEditor = (props) => {
     return (
         <Box>
             <Typography variant="h2"> {set.name}</Typography>
-            {_.cloneDeep(definitions)
-                .filter((definition) =>
-                    filterByOrigin
-                        ? filterByOrigin.includes(definition.origin)
-                        : true
-                )
+            {_.cloneDeep(filteredDefinitions)
                 .sort((a, b) => valueOrigin(a.origin) - valueOrigin(b.origin))
                 .map((definition) => {
                     const correspondingParameter = set.parameters.find(
@@ -105,7 +104,7 @@ const SetEditor = (props) => {
 SetEditor.propTypes = {
     set: PropTypes.object.isRequired,
     definitions: PropTypes.array.isRequired,
-    filterByOrigin: PropTypes.array, // undefined => show all, [] => do not show, [origin1, origin2] => show only in origin1 and origin2 category
+    filter: PropTypes.func,
     saveSet: PropTypes.func.isRequired,
 };
 

--- a/src/containers/ParametersContainer.jsx
+++ b/src/containers/ParametersContainer.jsx
@@ -22,7 +22,11 @@ import {
     DialogTitle,
 } from '@mui/material';
 import { makeGetMatches, MappingSlice } from '../redux/slices/Mapping';
-import { GroupEditionOrigin, SetType } from '../constants/models';
+import {
+    GroupEditionOrigin,
+    ParameterOrigin,
+    SetType,
+} from '../constants/models';
 import PropTypes from 'prop-types';
 import Stepper from '../components/2-molecules/Stepper';
 import SetGroupEditor from '../components/3-organisms/SetGroupEditor';
@@ -173,6 +177,7 @@ const ParametersContainer = ({
                 ) : (
                     <SetEditor
                         definitions={definitions}
+                        filterByOrigin={[ParameterOrigin.USER]} // FIX and NETWORK can not be modified here
                         saveSet={addOrModifySet}
                         set={currentSet}
                     />

--- a/src/containers/ParametersContainer.jsx
+++ b/src/containers/ParametersContainer.jsx
@@ -159,6 +159,10 @@ const ParametersContainer = ({
         close();
     };
 
+    // FIX and NETWORK can not be modified here
+    const definitionFilter = (definition) =>
+        [ParameterOrigin.USER].includes(definition.origin);
+
     return (
         <Dialog open={true} onClose={onClose}>
             <DialogTitle>
@@ -177,7 +181,7 @@ const ParametersContainer = ({
                 ) : (
                     <SetEditor
                         definitions={definitions}
-                        filterByOrigin={[ParameterOrigin.USER]} // FIX and NETWORK can not be modified here
+                        filter={definitionFilter}
                         saveSet={addOrModifySet}
                         set={currentSet}
                     />


### PR DESCRIPTION
Fixed and Network parameters must be not shown in the creation/editing group dialogue -> for example, in LoadAlphaBeta model, only alpha and beta are shown to edit, others network parameters are hidden.