### PR TITLE
Must make disable the check "All equipments share the same .par file" if network has not yet attached

### DIFF
--- a/src/components/2-molecules/ModelSelect.jsx
+++ b/src/components/2-molecules/ModelSelect.jsx
@@ -30,6 +30,7 @@ const ModelSelect = (props) => {
         changeGroup,
         editGroup,
         controlledParameters = false,
+        isNetworkAttached,
     } = props;
     const mappedModel = models.find(
         (modelToTest) => modelToTest.name === model
@@ -101,6 +102,7 @@ const ModelSelect = (props) => {
                             <Checkbox
                                 checked={isAbsolute}
                                 onChange={onAbsoluteChange}
+                                disabled={!isNetworkAttached}
                             />
                         </Grid>
                     </Grid>
@@ -151,6 +153,7 @@ ModelSelect.propTypes = {
     changeGroup: PropTypes.func.isRequired,
     editGroup: PropTypes.func.isRequired,
     controlledParameters: PropTypes.bool,
+    isNetworkAttached: PropTypes.bool.isRequired,
 };
 
 export default ModelSelect;

--- a/src/components/3-organisms/Automaton.jsx
+++ b/src/components/3-organisms/Automaton.jsx
@@ -32,6 +32,7 @@ const Automaton = (props) => {
         copyAutomaton,
         editGroup = () => {},
         controlledParameters = false,
+        isNetworkAttached = false,
     } = props;
     const { family, watchedElement, model, setGroup, properties } = automaton;
     const classes = useStyles(isAutomatonValid);
@@ -146,6 +147,7 @@ const Automaton = (props) => {
                 changeGroup={changeParameters}
                 editGroup={editGroup}
                 controlledParameters={controlledParameters}
+                isNetworkAttached={isNetworkAttached}
             />
         </Paper>
     );
@@ -165,6 +167,7 @@ Automaton.propTypes = {
     copyAutomaton: PropTypes.func.isRequired,
     editGroup: PropTypes.func.isRequired,
     controlledParameters: PropTypes.bool,
+    isNetworkAttached: PropTypes.bool,
 };
 
 export default Automaton;

--- a/src/components/3-organisms/Rule.jsx
+++ b/src/components/3-organisms/Rule.jsx
@@ -163,6 +163,7 @@ const Rule = (props) => {
                 changeGroup={changeParameters}
                 editGroup={editGroup}
                 controlledParameters={controlledParameters}
+                isNetworkAttached={isNetworkAttached}
             />
             {isNetworkAttached && !!filtersNumber && (
                 <Paper className={classes.matches}>

--- a/src/containers/AutomatonContainer.jsx
+++ b/src/containers/AutomatonContainer.jsx
@@ -13,7 +13,10 @@ import {
     MappingSlice,
 } from '../redux/slices/Mapping';
 import { makeGetModels } from '../redux/slices/Model';
-import { makeGetPossibleWatchedElements } from '../redux/slices/Network';
+import {
+    getCurrentNetworkId,
+    makeGetPossibleWatchedElements,
+} from '../redux/slices/Network';
 import PropTypes from 'prop-types';
 import Automaton from '../components/3-organisms/Automaton';
 import { GroupEditionOrigin, SetType } from '../constants/models';
@@ -38,6 +41,8 @@ const AutomatonContainer = ({ index, editParameters }) => {
     const controlledParameters = useSelector(
         (state) => state.mappings.controlledParameters
     );
+
+    const currentNetworkId = useSelector(getCurrentNetworkId);
     const dispatch = useDispatch();
     const changeFamily = (newFamily) =>
         dispatch(
@@ -150,6 +155,7 @@ const AutomatonContainer = ({ index, editParameters }) => {
             copyAutomaton={copyAutomaton}
             editGroup={editGroup}
             controlledParameters={controlledParameters}
+            isNetworkAttached={!!currentNetworkId}
         />
     );
 };

--- a/src/containers/RuleContainer.jsx
+++ b/src/containers/RuleContainer.jsx
@@ -30,6 +30,7 @@ import {
 import BooleanOperatorSelect from '../components/2-molecules/BooleanOperatorSelect';
 import FiltersGroup from '../components/3-organisms/FiltersGroup';
 import { GroupEditionOrigin } from '../constants/models';
+import { getCurrentNetworkId } from '../redux/slices/Network';
 
 const RuleContainer = ({ index, editParameters }) => {
     const getRule = useMemo(makeGetRule, []);
@@ -73,7 +74,7 @@ const RuleContainer = ({ index, editParameters }) => {
         (state) => state.mappings.controlledParameters
     );
 
-    const currentNetwork = useSelector((state) => state.network.currentNetwork);
+    const currentNetworkId = useSelector(getCurrentNetworkId);
     const dispatch = useDispatch();
     const [isAdvancedComposition, setIsAdvancedComposition] = useState(
         !canUseBasicMode
@@ -242,10 +243,10 @@ const RuleContainer = ({ index, editParameters }) => {
 
     const showAdvanced = isAdvancedComposition || filtersNumber === 1;
     useEffect(() => {
-        if (currentNetwork !== '' && isRuleValid) {
+        if (!!currentNetworkId && isRuleValid) {
             dispatch(getNetworkMatchesFromRule(index));
         }
-    }, [currentNetwork, isRuleValid, index, composition, dispatch]);
+    }, [currentNetworkId, isRuleValid, index, composition, dispatch]);
 
     return (
         <Rule
@@ -265,7 +266,7 @@ const RuleContainer = ({ index, editParameters }) => {
             unusedFilters={unusedFilters}
             editGroup={editGroup}
             controlledParameters={controlledParameters}
-            isNetworkAttached={currentNetwork !== ''}
+            isNetworkAttached={!!currentNetworkId}
         >
             {rule.filtersNumber > 0 ? (
                 <>

--- a/src/redux/slices/Network.js
+++ b/src/redux/slices/Network.js
@@ -61,6 +61,8 @@ export const makeGetPossibleWatchedElements = () =>
         }
     );
 
+export const getCurrentNetworkId = (state) => state.network.currentNetwork;
+
 // from current network id => get network object
 export const getCurrentNetworkObj = (state) => {
     const currentNetwork = state.network.currentNetwork;
@@ -68,6 +70,7 @@ export const getCurrentNetworkObj = (state) => {
         (knowNetwork) => knowNetwork.networkId === currentNetwork
     );
 };
+
 // Reducers
 
 export const getPropertyValuesFromFile = createAsyncThunk(


### PR DESCRIPTION
When no network attached, it must not uncheck "All equipments share the same .par file". If doing uncheck, a parameter set without network id is unuseful -> must make disable the check if network has not yet attached