### PR TITLE
Parameter Set Edition dialogue : Vertical list is not show when we have two matched equipments

### DIFF
--- a/src/containers/ParametersContainer.jsx
+++ b/src/containers/ParametersContainer.jsx
@@ -145,7 +145,7 @@ const ParametersContainer = ({
         });
         return completed;
     }, [currentGroup, definitions]);
-    const showVerticalSteps = showSteps && maxStep > 2;
+    const showVerticalSteps = showSteps && maxStep > 1;
     const isAllCompleted = () => {
         return Object.values(completed).every((v) => v);
     };


### PR DESCRIPTION
Parameter Set Creation/Edition  dialogue : Vertical list is not show when we have two matched equipments => a mistake from PR : https://github.com/gridsuite/griddyna-app/pull/43