### PR TITLE
Fix enum comparison in groovy script

### DIFF
--- a/src/constants/equipmentDefinition.js
+++ b/src/constants/equipmentDefinition.js
@@ -15,6 +15,7 @@ export const PropertyType = {
     STRING: 'STRING',
     BOOLEAN: 'BOOLEAN',
     NUMBER: 'NUMBER',
+    ENUM: 'ENUM',
 };
 Object.freeze(PropertyType);
 
@@ -22,7 +23,7 @@ export const EquipmentProperties = {
     GENERATOR: [
         {
             name: 'energySource',
-            type: PropertyType.STRING,
+            type: PropertyType.ENUM,
             values: ['OTHER', 'HYDRO'],
         },
         {
@@ -79,7 +80,7 @@ export const EquipmentProperties = {
     LOAD: [
         {
             name: 'loadType',
-            type: PropertyType.STRING,
+            type: PropertyType.ENUM,
             values: ['UNDEFINED'],
         },
         {

--- a/src/constants/operands.js
+++ b/src/constants/operands.js
@@ -28,6 +28,12 @@ export const NumberOperands = {
     NOT_IN: 'NOT_IN',
 };
 
+export const EnumOperands = {
+    ...BaseOperands,
+    IN: 'IN',
+    NOT_IN: 'NOT_IN',
+};
+
 export const multipleOperands = [
     NumberOperands.IN,
     NumberOperands.NOT_IN,

--- a/src/constants/operands.js
+++ b/src/constants/operands.js
@@ -18,6 +18,7 @@ export const StringOperands = {
     IN: 'IN',
     NOT_IN: 'NOT_IN',
 };
+
 export const NumberOperands = {
     ...BaseOperands,
     LOWER: 'LOWER',

--- a/src/utils/optionsBuilders.js
+++ b/src/utils/optionsBuilders.js
@@ -7,6 +7,7 @@
 
 import {
     BaseOperands,
+    EnumOperands,
     NumberOperands,
     StringOperands,
 } from '../constants/operands';
@@ -108,6 +109,25 @@ export function getOperandsOptions(propertyType) {
                 },
                 {
                     value: StringOperands.NOT_IN,
+                    label: 'is not in',
+                },
+            ];
+        case PropertyType.ENUM:
+            return [
+                {
+                    value: EnumOperands.EQUALS,
+                    label: '=',
+                },
+                {
+                    value: EnumOperands.NOT_EQUALS,
+                    label: '!=',
+                },
+                {
+                    value: EnumOperands.IN,
+                    label: 'is in',
+                },
+                {
+                    value: EnumOperands.NOT_IN,
                     label: 'is not in',
                 },
             ];


### PR DESCRIPTION
See: https://github.com/gridsuite/dynamic-mapping-server/issues/51
Ref : https://github.com/gridsuite/dynamic-mapping-server/pull/54

Support only 4 operands : "=", "!=", "is in", "is not in" for enum comparison