### PR TITLE
Dynamic Simulation - Allow a string representing a double terminated by a point

### DIFF
--- a/src/components/3-organisms/SetEditor.jsx
+++ b/src/components/3-organisms/SetEditor.jsx
@@ -39,7 +39,7 @@ const SetEditor = (props) => {
         const newValueToUse =
             filteredDefinitions.find(
                 (definition) => definition.name === parameterChanged
-            ).type === ParameterType.BOOL
+            ).type === ParameterType.DOUBLE
                 ? newValue.replace(',', '.')
                 : newValue;
         const updatedSet = _.cloneDeep(set);

--- a/src/utils/parameters.js
+++ b/src/utils/parameters.js
@@ -32,7 +32,7 @@ export const isParameterValueValid = (value, type) => {
         case ParameterType.STRING:
             return value.length > 0;
         case ParameterType.DOUBLE:
-            return /^-?\d+([.,]\d+)?$/.test(value);
+            return /^-?\d+([.]\d*)?$/.test(value);
         case ParameterType.INT:
             return /^\d+$/.test(value);
         default:


### PR DESCRIPTION
Java standard and js allows a double can be represented by a string terminated by a point 

Java : Double.parseDouble("1.") = 1
JS : +"1." = 1