### PR TITLE
Dynamic Simulation - Fix bug can not create a new parameter set

### DIFF
--- a/src/containers/RuleContainer.jsx
+++ b/src/containers/RuleContainer.jsx
@@ -133,8 +133,8 @@ const RuleContainer = ({ index, editParameters }) => {
             dispatch(
                 MappingSlice.actions.changeRuleParameters({
                     index,
-                    parameters: group.name,
-                    type: group.type,
+                    parameters: group?.name,
+                    type: group?.type,
                 })
             ),
         [dispatch, index]


### PR DESCRIPTION
This bug was corrected for automaton in the PR https://github.com/gridsuite/griddyna-app/pull/62

https://github.com/gridsuite/griddyna-app/blob/6da0e614d4bb4e5606182ce2ebe00e7523d9f05c/src/containers/AutomatonContainer.jsx#L90C40-L90C44

 but not yet fix for rule

![Peek 21-07-2023 16-39](https://github.com/gridsuite/griddyna-app/assets/117309322/77f836c6-902b-499a-95ea-0f8f73b275be)


