### PR TITLE
fix(authorization): handle flag parsing error

### DIFF
--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -147,6 +147,13 @@ export function fetchAuthorizationCodeFlowFeatureFlag() {
                         }`
                     );
                     return res.authorizationCodeFlowFeatureFlag;
+                })
+                .catch((error) => {
+                    console.error(error);
+                    console.log(
+                        `Something wrong happened when retrieving authentication.json: authorization code flow will be disabled`
+                    );
+                    return false;
                 });
         });
 }

--- a/src/utils/rest-api.js
+++ b/src/utils/rest-api.js
@@ -150,7 +150,7 @@ export function fetchAuthorizationCodeFlowFeatureFlag() {
                 })
                 .catch((error) => {
                     console.error(error);
-                    console.log(
+                    console.warn(
                         `Something wrong happened when retrieving authentication.json: authorization code flow will be disabled`
                     );
                     return false;


### PR DESCRIPTION
It would fail if the JSON is not present on the apps-metadata server