### PR TITLE
Fix version of commons-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.11.4",
                 "@emotion/styled": "^11.11.5",
-                "@gridsuite/commons-ui": "^0.53.0",
+                "@gridsuite/commons-ui": "0.53.0",
                 "@mui/icons-material": "^5.15.14",
                 "@mui/lab": "5.0.0-alpha.169",
                 "@mui/material": "^5.15.14",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
-        "@gridsuite/commons-ui": "^0.53.0",
+        "@gridsuite/commons-ui": "0.53.0",
         "@mui/icons-material": "^5.15.14",
         "@mui/lab": "5.0.0-alpha.169",
         "@mui/material": "^5.15.14",


### PR DESCRIPTION
Commons-UI have unstable API, so we must use exact version in dependencies to avoid incompatible newer version to be installed.