### PR TITLE
[GridDyna] Rename automaton family

### DIFF
--- a/src/constants/automatonDefinition.ts
+++ b/src/constants/automatonDefinition.ts
@@ -6,7 +6,7 @@
  */
 
 export const AutomatonFamily = {
-    CURRENT_LIMIT: 'CURRENT_LIMIT',
+    CURRENT: 'CURRENT',
     VOLTAGE: 'VOLTAGE',
 };
 Object.freeze(AutomatonFamily);

--- a/src/constants/automatonDefinition.ts
+++ b/src/constants/automatonDefinition.ts
@@ -4,9 +4,17 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { EquipmentType } from './equipmentType';
 
 export const AutomatonFamily = {
     CURRENT: 'CURRENT',
     VOLTAGE: 'VOLTAGE',
 };
 Object.freeze(AutomatonFamily);
+
+// Family is used just as alias, we need a mapping to real automaton types
+// to lookup associated automaton models for a given family
+export const AutomatonFamilyToAutomatonType = {
+    [AutomatonFamily.CURRENT]: EquipmentType.OVERLOAD_MANAGEMENT,
+    [AutomatonFamily.VOLTAGE]: EquipmentType.VOLTAGE,
+};

--- a/src/constants/equipmentType.ts
+++ b/src/constants/equipmentType.ts
@@ -12,6 +12,9 @@ export const EquipmentType = {
     LINE: 'LINE',
     TWO_WINDINGS_TRANSFORMER: 'TWO_WINDINGS_TRANSFORMER',
     STATIC_VAR_COMPENSATOR: 'STATIC_VAR_COMPENSATOR',
+    // automaton types
+    OVERLOAD_MANAGEMENT: 'OVERLOAD_MANAGEMENT',
+    VOLTAGE: 'VOLTAGE',
 };
 Object.freeze(EquipmentType);
 

--- a/src/constants/equipmentType.ts
+++ b/src/constants/equipmentType.ts
@@ -6,6 +6,7 @@
  */
 
 export const EquipmentType = {
+    // equipment types
     GENERATOR: 'GENERATOR',
     LOAD: 'LOAD',
     BUS: 'BUS',

--- a/src/containers/AutomatonContainer.jsx
+++ b/src/containers/AutomatonContainer.jsx
@@ -23,6 +23,7 @@ import {
 import PropTypes from 'prop-types';
 import Automaton from '../components/3-organisms/Automaton';
 import { GroupEditionOrigin, SetType } from '../constants/models';
+import { AutomatonFamilyToAutomatonType } from '../constants/automatonDefinition';
 
 const AutomatonContainer = ({ index, editParameters }) => {
     const getAutomaton = useMemo(makeGetAutomaton, []);
@@ -39,7 +40,9 @@ const AutomatonContainer = ({ index, editParameters }) => {
         isAutomatonValidSelector(state, index)
     );
     const getModels = useMemo(makeGetModels, []);
-    const models = useSelector((state) => getModels(state, automaton.family));
+    const models = useSelector((state) =>
+        getModels(state, AutomatonFamilyToAutomatonType[automaton.family])
+    );
 
     const getPropertyValues = useMemo(makeGetPropertyValues, []);
     const networkPropertyValues = useSelector((state) =>


### PR DESCRIPTION
After migration version dynawo 2.4.0, we want to change the automation family for Current limit automaton

See related PR: https://github.com/gridsuite/dynamic-mapping-server/pull/99