### PR TITLE
fix jest transpiling all node modules, make tests fast again

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "scripts": {
         "start": "PORT=3003 react-scripts start",
         "build": "react-scripts build",
-        "test": "react-scripts test --watchAll=false --transformIgnorePatterns \"node_modules/(?!@gridsuite/commons-ui)/\"",
+        "test": "react-scripts test --watchAll=false --transformIgnorePatterns \"node_modules/(?!@gridsuite/commons-ui|react-dnd|dnd-core|@react-dnd)\" --moduleNameMapper \"{\\\"^.+\\\\\\.(css|less|scss)$\\\": \\\"identity-obj-proxy\\\"}\"",
         "eject": "react-scripts eject",
         "lint": "eslint . --ext js,mjs,jsx,ts,mts,tsx --max-warnings 0",
         "licenses-check": "license-checker --summary --excludePrivatePackages --production --onlyAllow \"$( jq -r .onlyAllow[] license-checker-config.json | tr '\n' ';')\" --excludePackages \"$( jq -r .excludePackages[] license-checker-config.json | tr '\n' ';')\""


### PR DESCRIPTION
the previous regexp is bugged, it requires '//' in the filename !! As a result, all the files in node_modules don't pass the regex so nothing is ignored => everything is transformed

jest caches this in /tmp/jest_* so rerunning tests is fast, but the first time jest takes minutes to transform everything

also the previous config was incomplete for moduleNameMapper but this was not visible because it transformed everything anyway:
      Jest encountered an unexpected token
      Details:
        /node_modules/ag-grid-community/styles/ag-grid.css:1
        ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){.ag-icon {
                                                                                          ^
        SyntaxError: Unexpected token '.'

      Jest encountered an unexpected token
      Details:
        /node_modules/react-dnd/dist/index.js:1
        ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){export * from './core/index.js';
                                                                                          ^^^^^^
        SyntaxError: Unexpected token 'export'

note: passing this as an argument of the cli as a json string with backslashes in the keys makes it quite tricky