### PR TITLE
[GridDyna][Fix] When delete filter, rhf form values are not reset

### DIFF
--- a/src/containers/FilterContainer.jsx
+++ b/src/containers/FilterContainer.jsx
@@ -8,8 +8,6 @@
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-    getActiveMapping,
-    getFilteredRuleType,
     makeChangeFilterValueThenGetNetworkMatches,
     makeGetFilter,
     makeGetIsFilterValid,
@@ -39,9 +37,6 @@ const FilterContainer = ({ ruleIndex, equipmentType }) => {
     const filter = useSelector((state) => getFilter(state, ruleIndex));
 
     const { rules: query } = filter ?? {};
-
-    const filteredRuleType = useSelector(getFilteredRuleType);
-    const activeMapping = useSelector(getActiveMapping);
 
     const isFilterValid = useMemo(makeGetIsFilterValid, []);
     const isValid = useSelector((state) => isFilterValid(state, ruleIndex));
@@ -92,7 +87,7 @@ const FilterContainer = ({ ruleIndex, equipmentType }) => {
         {
             [EXPERT_FILTER_QUERY]: query,
         },
-        [activeMapping, filteredRuleType], // only reset form when mapping or type changed
+        [filter?.id], // only reset form when filter id changed
         onFormValid,
         undefined
     );

--- a/src/redux/slices/Mapping.js
+++ b/src/redux/slices/Mapping.js
@@ -24,6 +24,7 @@ import {
     rqbQuerySchemaValidator,
     yup,
 } from '@gridsuite/commons-ui';
+import { v4 as uuid4 } from 'uuid';
 import { enrichIdRqbQuery } from '../../utils/rqb-utils';
 
 const initialState = {
@@ -705,7 +706,8 @@ const reducers = {
         ruleToCopy.id = undefined;
         // if filter exists must unset filter id and provide all new ids for rule/group inside the filter
         if (ruleToCopy.filter?.id) {
-            ruleToCopy.filter.id = undefined;
+            // force reset filter with new id
+            ruleToCopy.filter.id = uuid4();
             // force reset with new ids for the whole query
             enrichIdRqbQuery(ruleToCopy.filter.rules, true);
         }
@@ -718,6 +720,8 @@ const reducers = {
 
         // create an empty expert filter
         const newFilter = getExpertFilterEmptyFormData();
+        // provide an id for new filter
+        newFilter.id = uuid4();
 
         const selectedRule = filterRulesByType(
             state.rules,


### PR DESCRIPTION
a small fix following PR:  https://github.com/gridsuite/griddyna-app/pull/95

When clicking on DELETE icon to remove a filter then add again a new filter, the ancient filter comes back (not really cleaned) and rule is invalid in red (not coherent to as we see in the screen)  

**BUG**
![delete_filter_griddyna](https://github.com/user-attachments/assets/1da083eb-7a6f-4067-b023-96f44f974b92)

**Reason:** when delete a filter, the hook useFormInit is not triggered because its dependencies are mapping name or equipment type have not changed.

**Solution:** give a new uuid for each filter and use the filter uuid to force reset rhf form values.

**CORRECTED**

![delete_filter_griddyna_corrected](https://github.com/user-attachments/assets/7410a68e-c21e-473f-9379-12cd114ea152)

