### PR TITLE
[GridDyna][Fix] Lost matched ids after saving a mapping

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -10,6 +10,8 @@ import _ from 'lodash';
 export const mergeSx = (...allSx) => allSx.flat();
 
 /**
+ * Copy properties from corresponding objects in a source array to objects in a target array.
+ * It returns the target array that contain modified objects
  *
  * @param targetArray the target array to copy to inside objects
  * @param sourceArray the source array from which to copy properties of objects

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -5,4 +5,25 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
+import _ from 'lodash';
+
 export const mergeSx = (...allSx) => allSx.flat();
+
+/**
+ *
+ * @param targetArray the target array to copy to inside objects
+ * @param sourceArray the source array from which to copy properties of objects
+ * @param matcher predicate to find the corresponding between a target element and a source element
+ * @param props properties names to copy, specified individually or in array
+ * @return the target array
+ */
+export const assignArray = (targetArray, sourceArray, matcher, ...props) => {
+    targetArray?.forEach((targetObj) => {
+        const matcherOfTarget = matcher(targetObj);
+        const sourceObj = sourceArray?.find(matcherOfTarget);
+        const pickObj = _.pick(sourceObj, props);
+        Object.assign(targetObj, pickObj);
+    });
+
+    return targetArray;
+};


### PR DESCRIPTION
After save a modified mapping which already having matched ids in rules => all matched ids disappear

**BUG**

![lost_matched_ids](https://github.com/user-attachments/assets/a5b37d08-5450-433a-b1f2-499b97a1b5fd)

**Reason:** matched ids are computed as a derived property in each rules so when reset an active rule with a fetched rule after saving, matched ids are not picked from the old rule

**Solution:** pick matched ids from the old rule during resetting with the fetched rule after saving a mapping

**CORRECTED**
![corrected_lost_matched_ids](https://github.com/user-attachments/assets/24c492f8-bdc2-40fd-adef-158cc0147e7f)
