### PR TITLE
[GridDyna][Fix] All automatons shown in the first tab when select a mapping

### DIFF
--- a/src/redux/slices/Mapping.js
+++ b/src/redux/slices/Mapping.js
@@ -656,11 +656,7 @@ const reducers = {
         state.filteredRuleType = action.payload;
     },
     changeFilteredFamily: (state, action) => {
-        const filteredAutomatonFamily = action.payload;
-        state.filteredAutomatonFamily =
-            state.filteredAutomatonFamily === filteredAutomatonFamily
-                ? ''
-                : filteredAutomatonFamily;
+        state.filteredAutomatonFamily = action.payload;
     },
     changeControlledParameters: (state) => {
         state.controlledParameters = !state.controlledParameters;


### PR DESCRIPTION
Small fix following to https://github.com/gridsuite/griddyna-app/pull/95

Select a mapping the open automatons, the first time automatons of same family shown correctly in their tab => switch to another mapping, all automatons shown in the same tab.

**BUG** 
![all_automatons_show_in_same_tab](https://github.com/user-attachments/assets/2cf36974-e5f5-4148-9442-6441863e09d0)

**Reason:** when dispatch changeFilterFamily action, the actual code check if currently in the same tab, reset empty for filteredAutomatonFamily. This is the old behaviour before the PR https://github.com/gridsuite/griddyna-app/pull/95 while we can change the family of a automaton

**Solution:** As we did as Rule, ignore check same tab.

**FIXED**
![correct_all_automatons_show_in_same_tab](https://github.com/user-attachments/assets/48fa3ce1-16b1-4b24-8871-8df351ad5720)
