### PR TITLE
[GridDyna][Fix] Multi-measurements are not shown in automatons properties

### DIFF
--- a/src/components/3-organisms/automaton/AutomatonProperties.tsx
+++ b/src/components/3-organisms/automaton/AutomatonProperties.tsx
@@ -15,6 +15,8 @@ import { Automaton } from '../../../redux/types/mapping.type';
 import { AutomationDefinition } from '../../../redux/types/model.type';
 import { EquipmentValues } from '../../../redux/types/network.type';
 
+const VALUE_DELIMITER = ',';
+
 export interface AutomatonPropertiesProps {
     automaton: Automaton;
     automatonDefinition: AutomationDefinition;
@@ -40,9 +42,9 @@ const AutomatonProperties = ({
                     propertyName,
                     propertyType
                 )(
-                    // convert an array to a string content with ',' delimiter
+                    // convert an array to a string content with VALUE_DELIMITER
                     _.isArray(propertyValue)
-                        ? _.join(propertyValue, ', ')
+                        ? _.join(propertyValue, VALUE_DELIMITER)
                         : propertyValue
                 );
             },
@@ -58,9 +60,12 @@ const AutomatonProperties = ({
                         (elem) => elem.name === propertyName
                     );
 
-                    // convert a string content with ',' delimiter to an array
+                    // convert a string content with VALUE_DELIMITER to an array
                     const propertyValue = propertyDefinition.multiple
-                        ? _.split(property?.value, ', ')
+                        ? _.map(
+                              _.split(property?.value, VALUE_DELIMITER),
+                              _.trim
+                          )
                         : property?.value ?? '';
 
                     const options =


### PR DESCRIPTION
Small fix following to https://github.com/gridsuite/griddyna-app/pull/95

**BUG**
![multi_measurements_not_shown](https://github.com/user-attachments/assets/b9b8745a-9cfe-465d-8e6f-f044f617b1ae)

**Reason:** the example mapping has been changed in PR: https://github.com/gridsuite/dynamic-mapping-server/pull/96/files#diff-13f805387e43e73fea2005d1515ace3eda4d1890ccad5a282022d27eef0cfdadR154 which does not contain empty space after the separation comma.

**Solution:** adapt the encode/decode of a string in which multi-values separated by comma to be enable to tolerate empty space.

**CORRECTED**
![corrected_multi_measurements_not_shown](https://github.com/user-attachments/assets/524f69f2-2fa0-4e19-b377-0f18a1106626)
