### PR TITLE
Fix Prettier to work with IDE plugins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,47 +1,34 @@
 {
-  "root": true,
-  "extends": [
-    "react-app",
-    "plugin:prettier/recommended",
-    "plugin:react/jsx-runtime"
-  ],
-  "parserOptions": {
-    "project": "./tsconfig.json"
-  },
-  "ignorePatterns": [
-    // node_modules is implicitly always ignored
-    "build",
-    "coverage",
-    "vite.config.ts",
-    "jest.config.ts",
-    "jest.setup.ts"
-  ],
-  "settings": {
-    "import/parsers": {
-      "@typescript-eslint/parser": [
-        ".ts",
-        ".tsx"
-      ]
-    },
-    "import/resolver": {
-      "typescript": {
-        "alwaysTryTypes": true,
+    "root": true,
+    "extends": ["react-app", "plugin:prettier/recommended", "plugin:react/jsx-runtime"],
+    "parserOptions": {
         "project": "./tsconfig.json"
-      }
+    },
+    "ignorePatterns": [
+        // node_modules is implicitly always ignored
+        "build",
+        "coverage"
+    ],
+    "settings": {
+        "import/parsers": {
+            "@typescript-eslint/parser": [".ts", ".tsx"]
+        },
+        "import/resolver": {
+            "typescript": {
+                "alwaysTryTypes": true,
+                "project": "./tsconfig.json"
+            }
+        }
+    },
+    "plugins": ["react-refresh"],
+    "rules": {
+        "prettier/prettier": "warn",
+        "curly": "error",
+        "no-console": "off",
+        "react/jsx-props-no-spreading": "off",
+        "react/require-default-props": "off",
+        "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+        "import/prefer-default-export": "off",
+        "react-refresh/only-export-components": ["error", { "allowConstantExport": true }]
     }
-  },
-  "plugins": ["react-refresh"],
-  "rules": {
-    "prettier/prettier": "warn",
-    "curly": "error",
-    "no-console": "off",
-    "react/jsx-props-no-spreading": "off",
-    "react/require-default-props": "off",
-    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
-    "import/prefer-default-export": "off",
-    "react-refresh/only-export-components": [
-      "error",
-      { "allowConstantExport": true }
-    ]
-  }
 }

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-node-options=--experimental-strip-types

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,9 +1,9 @@
 {
-  "presets": [
-    "@babel/preset-env",
-    ["@babel/preset-react", { "runtime": "automatic" }],
-    "@babel/preset-typescript",
-    "babel-preset-vite"
-  ],
-  "plugins": ["@babel/plugin-transform-runtime"]
+    "presets": [
+        "@babel/preset-env",
+        ["@babel/preset-react", { "runtime": "automatic" }],
+        "@babel/preset-typescript",
+        "babel-preset-vite"
+    ],
+    "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "vite-tsconfig-paths": "^5.1.4"
             },
             "engines": {
-                "node": ">=22.6.0",
+                "node": ">=22",
                 "npm": "^10.9.2"
             }
         },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "type": "module",
     "engines": {
-        "node": ">=22.6.0",
+        "node": ">=22",
         "npm": "^10.9.2"
     },
     "scripts": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -5,9 +5,15 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-import type { Config } from 'prettier';
-
-export default {
+// @ts-check
+/**
+ * @see https://prettier.io/docs/configuration
+ * @type {import("prettier").Config}
+ * @todo Pass this file in typescript when the IDEs plugins support it<ul>
+ *       <li>https://github.com/prettier/prettier-vscode/issues/3623</li>
+ *       <li>https://youtrack.jetbrains.com/issue/WEB-71713/Support-for-prettier.config.ts</li></ul>
+ */
+const config = {
     trailingComma: 'es5',
     tabWidth: 4,
     printWidth: 120,
@@ -24,4 +30,5 @@ export default {
             options: { tabWidth: 2 },
         },
     ],
-} satisfies Config;
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,10 @@
     },
     "include": [
         "src",
+        "jest.setup.ts",
         // We must list config files in typescript because needed by prettier when called by eslint as plugin
-        "prettier.config.mts"
+        "jest.config.ts",
+        "prettier.config.js",
+        "vite.config.ts"
     ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@
 
 import react from '@vitejs/plugin-react';
 import { CommonServerOptions, defineConfig } from 'vite';
+// @ts-expect-error See https://github.com/gxmari007/vite-plugin-eslint/issues/79
 import eslint from 'vite-plugin-eslint';
 import svgr from 'vite-plugin-svgr';
 import tsconfigPaths from 'vite-tsconfig-paths';


### PR DESCRIPTION
The Prettier plugin in IDEs ([VSCode](https://github.com/prettier/prettier-vscode/issues/3623), [~IntelliJ~ WebStorm](https://youtrack.jetbrains.com/issue/WEB-71713/Support-for-prettier.config.ts)) don't support the experimental `prettier.config.ts` format.

Reverting to `prettier.config.js` until the plugins support it.