### PR TITLE
Check styles declaration against MUI `Theme` with TypeScript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@emotion/react": "^11.14.0",
                 "@emotion/styled": "^11.14.0",
-                "@gridsuite/commons-ui": "0.117.0",
+                "@gridsuite/commons-ui": "file:../commons-ui/gridsuite-commons-ui-0.121.0.tgz",
                 "@hookform/resolvers": "^4.0.0",
                 "@mui/icons-material": "^5.16.14",
                 "@mui/lab": "5.0.0-alpha.175",
@@ -3046,9 +3046,9 @@
             }
         },
         "node_modules/@gridsuite/commons-ui": {
-            "version": "0.117.0",
-            "resolved": "https://registry.npmjs.org/@gridsuite/commons-ui/-/commons-ui-0.117.0.tgz",
-            "integrity": "sha512-RxcucuCoMrNg/kaiSzISYUEYdpknZHmVJYPQADA8XqI7/sXY9yQM1/hje6DiIM2PXoVbEUaYjmft9uqT9yvXYA==",
+            "version": "0.121.0",
+            "resolved": "file:../commons-ui/gridsuite-commons-ui-0.121.0.tgz",
+            "integrity": "sha512-vGcYW3Ky5lIs4fbifDnFetG3t2rUOd70vkP3Gl9pNWzNSCvDm6RN97SL9sWZ0mBQw2gTrXzFZutepFxEtAopGQ==",
             "license": "MPL-2.0",
             "dependencies": {
                 "@ag-grid-community/locale": "^33.1.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@gridsuite/commons-ui": "0.117.0",
+        "@gridsuite/commons-ui": "file:../commons-ui/gridsuite-commons-ui-0.121.0.tgz",
         "@hookform/resolvers": "^4.0.0",
         "@mui/icons-material": "^5.16.14",
         "@mui/lab": "5.0.0-alpha.175",

--- a/src/components/2-molecules/SetGroupSelectStyle.ts
+++ b/src/components/2-molecules/SetGroupSelectStyle.ts
@@ -4,6 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { type MuiStyles } from '@gridsuite/commons-ui';
 
 export const styles = {
     titleSelect: {
@@ -26,4 +27,4 @@ export const styles = {
         alignItems: 'center',
         paddingLeft: 1,
     },
-};
+} as const satisfies MuiStyles;

--- a/src/components/2-molecules/TabBarStyles.ts
+++ b/src/components/2-molecules/TabBarStyles.ts
@@ -4,10 +4,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
+import { type MuiStyles } from '@gridsuite/commons-ui';
 
 export const styles = {
     tabWithError: {
         '&.Mui-selected': { color: 'error.main' },
         color: 'error.main',
     },
-};
+} as const satisfies MuiStyles;

--- a/src/components/3-organisms/automaton/AutomatonPropertiesStyle.ts
+++ b/src/components/3-organisms/automaton/AutomatonPropertiesStyle.ts
@@ -4,10 +4,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import { Theme } from '@mui/material';
+import { type MuiStyles } from '@gridsuite/commons-ui';
 
 export const styles = {
-    gridContainer: (theme: Theme) => ({
+    gridContainer: (theme) => ({
         border: 1,
         borderRadius: 1,
         borderColor: theme.palette.grey[500],
@@ -32,4 +32,4 @@ export const styles = {
     group: {
         backgroundColor: 'rgba(255, 255, 255, 0.16)',
     },
-};
+} as const satisfies MuiStyles;


### PR DESCRIPTION
Fix styles definitions by telling typescript to check against MUI `Theme` declaration.

Depends on gridsuite/commons-ui#855