### PR TITLE
Refactor: Reorder tsconfig.json compilerOptions logically

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,19 @@
 {
     "compilerOptions": {
         "target": "es6",
-        "baseUrl": "src",
         "lib": ["dom", "dom.iterable", "esnext"],
-        "allowJs": true,
-        "skipLibCheck": true,
-        "esModuleInterop": true,
-        "allowSyntheticDefaultImports": true,
-        "strict": true,
-        "forceConsistentCasingInFileNames": true,
-        "noFallthroughCasesInSwitch": true,
+        "jsx": "react-jsx",
+        "baseUrl": "src",
         "module": "esnext",
         "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "isolatedModules": true,
-        "noEmit": true,
-        "jsx": "react-jsx"
+        "allowJs": true,
+        "strict": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true,
+        "noFallthroughCasesInSwitch": true,
+        "noEmit": true
     },
     "include": [
         "src",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,27 @@
 {
     "compilerOptions": {
+        /* Language and Environment */
         "target": "es6",
         "lib": ["dom", "dom.iterable", "esnext"],
         "jsx": "react-jsx",
+
+        /* Modules and Resolution */
         "baseUrl": "src",
         "module": "esnext",
         "moduleResolution": "bundler",
         "resolveJsonModule": true,
         "isolatedModules": true,
+
+        /* JavaScript Support */
         "allowJs": true,
+
+        /* Type Checking */
         "strict": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,
+
+        /* Output */
         "noEmit": true
     },
     "include": [


### PR DESCRIPTION
This PR reorders the compilerOptions keys in tsconfig.json based on a logical grouping (Language & Environment, Modules & Resolution, JavaScript Support, Type Checking, and Output) rather than alphabetical order.